### PR TITLE
Copy Pasta, Grid, Create In Selection

### DIFF
--- a/Assets/C#/CopyPaste.cs
+++ b/Assets/C#/CopyPaste.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Oxide.Game.Rust.Cui;
@@ -10,34 +10,37 @@ public class CopyPaste : MonoBehaviour {
 
     public void Copy()
     {
-        clipboardBuffer = CollectionManager.GetSelectedCui();
-        if (Input.GetKey(KeyCode.LeftAlt))
-        {
+        if (Input.GetKey(KeyCode.LeftControl) && Input.GetKeyDown(KeyCode.C)) {
+            clipboardBuffer = CollectionManager.GetSelectedCui();
             clipboardBuffer.ForEach(AddRectPixelComponent);
         }
     }
 
     public void Paste()
     {
-        foreach (var element in clipboardBuffer)
-        {
-            var cui = CuiManager.Create();
-            var pixelComponent = element.Components.OfType<RectPixelComponent>().FirstOrDefault();
-            if (pixelComponent != null)
-            {
-                element.Components.Remove(pixelComponent);
-            }
+        if (Input.GetKey(KeyCode.LeftControl) && Input.GetKeyDown(KeyCode.V) && clipboardBuffer != null) {
+            foreach (var element in clipboardBuffer) {
+                var cui = CuiManager.Create();
+                var pixelComponent = element.Components.OfType<RectPixelComponent>().FirstOrDefault();
+                if (pixelComponent != null) {
+                    element.Components.Remove(pixelComponent);
+                }
 
-            cui.Load(element);
+                cui.Load(element);
 
-            if (pixelComponent != null)
-            {
-                element.Components.Add(pixelComponent);
-                var rTransform = cui.GetComponent<RectTransformComponent>();
-                rTransform.SetPixelLocalPosition(pixelComponent.Position);
-                rTransform.SetPixelSize(pixelComponent.Size);
+                if (pixelComponent == null) {
+                    element.Components.Add(pixelComponent);
+                    var rTransform = cui.GetComponent<RectTransformComponent>();
+                    rTransform.SetPixelLocalPosition(pixelComponent.Position);
+                    rTransform.SetPixelSize(pixelComponent.Size);
+                }
             }
         }
+    }
+    
+    private void Update() {
+        Copy();
+        Paste();
     }
 
     private void AddRectPixelComponent(CuiElement element)

--- a/Assets/C#/CuiManager.cs
+++ b/Assets/C#/CuiManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
@@ -18,18 +18,39 @@ public class CuiManager : MonoBehaviour
     private void Update()
     {
         if (Input.GetKeyDown( KeyCode.X ))
-        {
-            var obj = CreateInternal();
-            var rTransform = obj.GetComponent<RectTransformComponent>();
-            rTransform.SetPixelLocalPosition( new Vector2( 100, 100 ) );
-            rTransform.SetPixelSize( new Vector2( 100, 100 ) );
+            CreateInternalParent();
+    }
+
+    private CUIObject CreateInternalParent() {
+        var obj = PoolManager.Get(PrefabType.Cui);
+
+        GameObject selectedObj = null;
+        try {
+            var selected = CUIObject.Selection; //Get the currently selected object, this throws errors if the selection is HUD/OVERLAY
+            selectedObj = HierarchyView.GetCurrent().Where(selected.Contains).Select(p => p.gameObject).ToList()[0];
+        } catch (Exception) {
+
         }
+
+        var rTransform = obj.GetComponent<RectTransformComponent>();
+        if (selectedObj != null) {
+            obj.transform.SetParent(selectedObj.transform, false);
+            Hierarchy.Lookup[ obj ].SetParent( Hierarchy.Lookup[ selectedObj ] );
+            rTransform.SetPixelLocalPosition(new Vector2(0, 0));
+        } else {
+            obj.transform.SetParent(m_RootDefault.transform, false);
+            Hierarchy.Lookup[ obj ].SetParent( Hierarchy.Lookup[ m_RootDefault ] );
+            rTransform.SetPixelLocalPosition(new Vector2(100, 100));
+        }
+        rTransform.SetPixelSize(new Vector2(100, 100));
+
+        return CUIObject.Lookup[ obj ];
     }
 
     private CUIObject CreateInternal()
     {
-        var obj = PoolManager.Get( PrefabType.Cui );
-        obj.transform.SetParent( m_RootDefault.transform, false );
+        var obj = PoolManager.Get(PrefabType.Cui);
+        obj.transform.SetParent(m_RootDefault.transform, false);
         Hierarchy.Lookup[ obj ].SetParent( Hierarchy.Lookup[ m_RootDefault ] );
         return CUIObject.Lookup[ obj ];
     }

--- a/Assets/C#/Interactive/Interact.cs
+++ b/Assets/C#/Interactive/Interact.cs
@@ -93,9 +93,10 @@ public class Interact : MonoBehaviour, IPoolHandler, ISelectHandler
             if (Input.GetKeyDown(KeyCode.Equals))
             {
                 currentGridIndex++;
+                var gridCount = Grid.Count();
                 if (currentGridIndex == Grid.Count())
                 {
-                    currentGridIndex = 0;
+                    currentGridIndex = gridCount - 1;
                 }
             }
             if (Input.GetKeyDown(KeyCode.Minus))
@@ -103,7 +104,7 @@ public class Interact : MonoBehaviour, IPoolHandler, ISelectHandler
                 currentGridIndex--;
                 if (currentGridIndex == -1)
                 {
-                    currentGridIndex = Grid.Count() - 1;
+                    currentGridIndex = 0;
                 }
             }
         }

--- a/github/KEYS.md
+++ b/github/KEYS.md
@@ -17,7 +17,7 @@
 | **Ctrl+Shift+V** | Paste |
 | **Ctrl+Left Bracket** | Enable gird on seleceted object |
 | **Ctrl+Equal** | Increase grid size on selected object |
-| **Ctrl+Minus | Decrease grid size on selected object |
+| **Ctrl+Minus** | Decrease grid size on selected object |
 | **X** | New object |
 
 # Русский

--- a/github/KEYS.md
+++ b/github/KEYS.md
@@ -15,6 +15,10 @@
 | **Ctrl+Shift+C** | Copy by anchors |
 | **Ctrl+Shift+Alt+C** | Copy by pixels |
 | **Ctrl+Shift+V** | Paste |
+| **Ctrl+Left Bracket** | Enable gird on seleceted object |
+| **Ctrl+Equal** | Increase grid size on selected object |
+| **Ctrl+Minus | Decrease grid size on selected object |
+| **X** | New object |
 
 # Русский
 


### PR DESCRIPTION
Added the ability to move controls around on a grid
Fixed copying and pasting, and fixed the paste position not updating. 
Creating any new controls while you have a selection will create the new control as a sub control to your selection. 